### PR TITLE
V1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,22 @@ Serhii\Ago\Lang::set('ru');
 For outputting post publishing date or something else you can just pass the date to method `ago()`. It will count the interval between now and given date and returns needed format.
 
 ```php
-use Serhii\Ago\Time;
-
-Time::ago('2019-10-23 10:46:00'); // after 10 seconds outputs: 10 seconds ago
+$now = date('Y-m-d H:i:s');
+Serhii\Ago\Time::ago($now); // after 10 seconds outputs: 10 seconds ago
 ```
 
-If you want to show last user login like if user is online or not, you can pass `Ago::ONLINE` constant as the seconds argument. All it does is just displaying **Online** if date interval withing 60 seconds.
+If you want to show last user login like if user is online or not, you can pass `Ago::ONLINE` constant as the seconds argument. All it does is just displaying **Online** if date interval within 60 seconds.
 
 ```php
-use Serhii\Ago\Time;
+$now = date('Y-m-d H:i:s');
+Time::ago($now, Time::ONLINE); // within 60 seconds output is: Online
+```
 
-Time::ago('2019-10-23 10:46:00', Time::ONLINE);
+If you want to remove suffix from date and have "5 minutes" instead of "5 minutes ago" there is a flag `Time::NO_SUFFIX` available for this operation.
+
+```php
+$now = date('Y-m-d H:i:s');
+Time::ago($now, Time::NO_SUFFIX); // after 5 seconds output is: 5 seconds
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $now = date('Y-m-d H:i:s');
 Serhii\Ago\Time::ago($now); // after 10 seconds outputs: 10 seconds ago
 ```
 
-If you want to show last user login like if user is online or not, you can pass `Ago::ONLINE` constant as the seconds argument. All it does is just displaying **Online** if date interval within 60 seconds.
+If you want to show last user login like if user is online or not, you can pass `Ago::ONLINE` constant as the seconds argument. All it does is just displaying **Online** if date interval within 60 seconds. After 60 seconds output will be the same as usually "x time ago" format.
 
 ```php
 $now = date('Y-m-d H:i:s');

--- a/src/Time.php
+++ b/src/Time.php
@@ -5,6 +5,9 @@ namespace Serhii\Ago;
 class Time
 {
     const ONLINE = 1;
+    const NO_SUFFIX = 2;
+
+    private static $flag = 0;
 
     /**
      * Takes date string and returns converted date
@@ -16,6 +19,8 @@ class Time
      */
     public static function ago(string $date, ?int $flag = null): string
     {
+        self::$flag = $flag;
+
         Lang::includeTranslations();
 
         $seconds = strtotime('now') - strtotime($date);
@@ -65,7 +70,8 @@ class Time
         }
 
         $time = Lang::getTimeTranslations();
+        $suffix = self::$flag === self::NO_SUFFIX ? '' : ' ' . Lang::trans('ago');
 
-        return "$num {$time[$type][$index]} " . Lang::trans('ago');
+        return "$num {$time[$type][$index]}" . $suffix;
     }
 }

--- a/src/Time.php
+++ b/src/Time.php
@@ -7,6 +7,11 @@ class Time
     const ONLINE = 1;
     const NO_SUFFIX = 2;
 
+    /**
+     * @var int $flag This property will be equal to the flag that
+     * will be passed in ago() method as the second argument. It
+     * allows to know what flag was passed in any part of this class
+     */
     private static $flag = 0;
 
     /**

--- a/tests/AgoTest.php
+++ b/tests/AgoTest.php
@@ -124,7 +124,7 @@ class AgoTest extends TestCase
     {
         Lang::set($lang);
         $time = Time::ago(CarbonImmutable::now()->subSeconds($seconds)->toDateTimeString(), Time::ONLINE);
-        $this->assertSame($lang === 'ru' ? 'В сети' : 'Online', $time); //TODO: refactore
+        $this->assertSame($lang === 'ru' ? 'В сети' : 'Online', $time);
     }
 
     public function Provider_returns_online_within_60_seconds_and_if_second_arg_is_passes(): array
@@ -140,6 +140,33 @@ class AgoTest extends TestCase
             [20, 'ru'],
             [30, 'ru'],
             [58, 'ru'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider Provider_for_returns_time_without_suffix_if_flag_is_passes
+     * @param $lang
+     * @param $time
+     * @param $expect
+     */
+    public function returns_time_without_suffix_if_flag_is_passes($lang, $time, $expect): void
+    {
+        Lang::set($lang);
+        $this->assertSame($expect, Time::ago($time, Time::NO_SUFFIX));
+    }
+
+    public function Provider_for_returns_time_without_suffix_if_flag_is_passes(): array
+    {
+        return [
+            ['en', CarbonImmutable::now()->subMinute()->toDateTimeString(), '1 minute'],
+            ['en', CarbonImmutable::now()->subMinutes(25)->toDateTimeString(), '25 minutes'],
+            ['en', CarbonImmutable::now()->subMonth()->toDateTimeString(), '1 month'],
+            ['en', CarbonImmutable::now()->subYear()->toDateTimeString(), '1 year'],
+            ['ru', CarbonImmutable::now()->subMinute()->toDateTimeString(), '1 минута'],
+            ['ru', CarbonImmutable::now()->subMinutes(25)->toDateTimeString(), '25 минут'],
+            ['ru', CarbonImmutable::now()->subMonth()->toDateTimeString(), '1 месяц'],
+            ['ru', CarbonImmutable::now()->subYear()->toDateTimeString(), '1 год'],
         ];
     }
 }


### PR DESCRIPTION
* New flag for Time::ago() method with the name Time::NO_SUFFIX. It allows to remove the end of the result date. For example without flag you will get output "5 seconds ago" but with new flag the output will be "5 seconds"