### PR TITLE
V2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ## v2.3.0 (2022-01-27)
 
-- Added deprecation notice when you try to use `TimeAgo::UPCOMING` option;
+- Added deprecation notice when you try to use `Option::UPCOMING` option;
+- Closed [issue #34](vhttps://github.com/SerhiiCho/ago/issues/34). Changed `trans` method to except future dates and return correct result.
 
 ----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ----
 
+## v2.3.0 (2022-01-27)
+
+- Added deprecation notice when you try to use `TimeAgo::UPCOMING` option;
+
+----
+
 ## v2.2.1 (2022-01-16)
 
 - Fixed mistake in composer.json file with carbon library being as a dev dependency.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,13 @@ TimeAgo::trans((new \DateTime('now - 5 minutes'))); // output: 5 minutes ago
 TimeAgo::trans((new \DateTimeImmutable('now - 5 minutes'))); // output: 5 minutes ago
 ```
 
-It's very convenient, because you can pass almost any date format and it will give you the correct output.
+When you pass the date in the future, it will output the interval to this date. It's very convenient, because you can pass almost any date format and it will give you the correct output.
+
+```php
+TimeAgo::trans(time() + 86400); // output: 1 day
+TimeAgo::trans('now + 10 minutes'); // output: 10 minutes
+```
+
 
 > If you use version `< 2.2.0` then `TimeAgo::trans()` method except only type string.
 
@@ -109,7 +115,6 @@ All options are available in `Serhii\Ago\Option::class` as constants.
 | --- | --- |
 | Option::ONLINE | Display "Online" if date interval within 60 seconds. After 60 seconds output will be the same as usually "x time ago" format. |
 | Option::NO_SUFFIX | Remove suffix from date and have "5 minutes" instead of "5 minutes ago". |
-| Option::UPCOMING | This option reverts the output and calculates period not from the past date but to future date. It is useful when you need to display a counter for some date in the future. If you pass a date that is 2 months in the future, the output will be `2 months`. |
 | Option::UPPER | Set the output to uppercase. |
 
 ## Quick Start

--- a/src/TimeAgo.php
+++ b/src/TimeAgo.php
@@ -73,6 +73,13 @@ final class TimeAgo
     {
         $this->options = $options ?? [];
 
+        if ($this->optionIsSet(Option::UPCOMING)) {
+            trigger_error(
+                'Option::UPCOMING is deprecated and will be removed in the next major version v3.0.0',
+                E_USER_DEPRECATED
+            );
+        }
+
         $seconds = $this->optionIsSet(Option::UPCOMING)
             ? $date_timestamp - \time()
             : \time() - $date_timestamp;

--- a/src/TimeAgo.php
+++ b/src/TimeAgo.php
@@ -75,14 +75,17 @@ final class TimeAgo
 
         if ($this->optionIsSet(Option::UPCOMING)) {
             trigger_error(
-                'Option::UPCOMING is deprecated and will be removed in the next major version v3.0.0',
+                'Option::UPCOMING is deprecated. Read more: https://github.com/SerhiiCho/ago/issues/34',
                 E_USER_DEPRECATED
             );
         }
 
-        $seconds = $this->optionIsSet(Option::UPCOMING)
-            ? $date_timestamp - \time()
-            : \time() - $date_timestamp;
+        $seconds = \time() - $date_timestamp;
+
+        if ($seconds < 0) {
+            $seconds = $date_timestamp - \time();
+            $this->options[] = Option::UPCOMING;
+        }
 
         $minutes = (int) \round($seconds / 60);
         $hours = (int) \round($seconds / 3600);

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -131,41 +131,6 @@ class OptionsTest extends TestCase
     }
 
     /**
-     * @dataProvider provider_returns_times_left_for_a_date_in_future_with_UPCOMING_option
-     * @test
-     *
-     * @param string $date
-     * @param string $lang
-     * @param string $result
-     *
-     * @throws \Exception
-     */
-    public function returns_times_left_for_a_date_in_future_with_UPCOMING_option(string $date, string $lang, string $result): void
-    {
-        Lang::set($lang);
-        $this->assertSame($result, TimeAgo::trans($date, Option::UPCOMING));
-    }
-
-    public function provider_returns_times_left_for_a_date_in_future_with_UPCOMING_option(): array
-    {
-        return [
-            [CarbonImmutable::now()->addMinutes(2)->toDateTimeString(), 'en', '2 minutes'],
-            [CarbonImmutable::now()->addMinutes(10)->toDateTimeString(), 'en', '10 minutes'],
-            [CarbonImmutable::now()->addHours(13)->toDateTimeString(), 'en', '13 hours'],
-            [CarbonImmutable::now()->addMonth()->toDateTimeString(), 'en', '1 month'],
-            [CarbonImmutable::now()->addYears(10)->toDateTimeString(), 'en', '10 years'],
-            [CarbonImmutable::now()->addYear()->toDateTimeString(), 'en', '1 year'],
-            [CarbonImmutable::now()->addMinutes(2)->toDateTimeString(), 'ru', '2 минуты'],
-            [CarbonImmutable::now()->addMinutes(10)->toDateTimeString(), 'ru', '10 минут'],
-            [CarbonImmutable::now()->addHours(13)->toDateTimeString(), 'ru', '13 часов'],
-            [CarbonImmutable::now()->addMonth()->toDateTimeString(), 'ru', '1 месяц'],
-            [CarbonImmutable::now()->addMonths(10)->toDateTimeString(), 'ru', '10 месяцев'],
-            [CarbonImmutable::now()->addYears(10)->toDateTimeString(), 'ru', '10 лет'],
-            [CarbonImmutable::now()->addYear()->toDateTimeString(), 'ru', '1 год'],
-        ];
-    }
-
-    /**
      * @test
      * @dataProvider provider_for_returns_time_in_uppercase
      *

--- a/tests/TimeAgoTest.php
+++ b/tests/TimeAgoTest.php
@@ -85,8 +85,7 @@ class TimeAgoTest extends TestCase
     public function trans_method_returns_correct_result_after_passing_a_DateTime_object(
         DateTimeInterface $timestamp,
         string $expect
-    ): void
-    {
+    ): void {
         $this->assertSame($expect, TimeAgo::trans($timestamp));
     }
 
@@ -108,8 +107,7 @@ class TimeAgoTest extends TestCase
     public function trans_method_returns_correct_result_after_passing_a_Carbon_object(
         CarbonInterface $timestamp,
         string $expect
-    ): void
-    {
+    ): void {
         $this->assertSame($expect, TimeAgo::trans($timestamp));
     }
 
@@ -142,6 +140,44 @@ class TimeAgoTest extends TestCase
             ['safjldkfj'],
             ['afjdsalkfjdsklfj'],
             ['__'],
+        ];
+    }
+
+    /**
+     * @dataProvider provider_returns_times_left_for_a_date_in_future_with_UPCOMING_option
+     * @test
+     *
+     * @param string $date
+     * @param string $lang
+     * @param string $result
+     *
+     * @throws \Exception
+     */
+    public function trans_method_returns_times_left_for_a_date_in_future(
+        string $date,
+        string $lang,
+        string $result
+    ): void {
+        Lang::set($lang);
+        $this->assertSame($result, TimeAgo::trans($date));
+    }
+
+    public function provider_returns_times_left_for_a_date_in_future_with_UPCOMING_option(): array
+    {
+        return [
+            [CarbonImmutable::now()->addMinutes(2)->toDateTimeString(), 'en', '2 minutes'],
+            [CarbonImmutable::now()->addMinutes(10)->toDateTimeString(), 'en', '10 minutes'],
+            [CarbonImmutable::now()->addHours(13)->toDateTimeString(), 'en', '13 hours'],
+            [CarbonImmutable::now()->addMonth()->toDateTimeString(), 'en', '1 month'],
+            [CarbonImmutable::now()->addYears(10)->toDateTimeString(), 'en', '10 years'],
+            [CarbonImmutable::now()->addYear()->toDateTimeString(), 'en', '1 year'],
+            [CarbonImmutable::now()->addMinutes(2)->toDateTimeString(), 'ru', '2 минуты'],
+            [CarbonImmutable::now()->addMinutes(10)->toDateTimeString(), 'ru', '10 минут'],
+            [CarbonImmutable::now()->addHours(13)->toDateTimeString(), 'ru', '13 часов'],
+            [CarbonImmutable::now()->addMonth()->toDateTimeString(), 'ru', '1 месяц'],
+            [CarbonImmutable::now()->addMonths(10)->toDateTimeString(), 'ru', '10 месяцев'],
+            [CarbonImmutable::now()->addYears(10)->toDateTimeString(), 'ru', '10 лет'],
+            [CarbonImmutable::now()->addYear()->toDateTimeString(), 'ru', '1 год'],
         ];
     }
 }


### PR DESCRIPTION
- Added deprecation notice when you try to use `Option::UPCOMING` option;
- Closed [issue #34](vhttps://github.com/SerhiiCho/ago/issues/34). Changed `trans` method to except future dates and return correct result.