### PR TITLE
V3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Removed budge from `README.md` file that shows stable release;
 - Added `Option::JUST_NOW` option that print `Just now` if time is within 1 minute;
+- Added throwing `InvalidOptionsException` when you pass `JUST_NOW` and `ONLINE` options at the same time;
 
 ----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v3.0.1 (2022-01-28)
 
 - Removed budge from `README.md` file that shows stable release;
+- Added `Option::JUST_NOW` option that print `Just now` if time is within 1 minute;
 
 ----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ----
 
+## v3.0.1 (2022-01-27)
+
+- Removed budge from `README.md` file that shows stable release;
+
+----
+
 ## v3.0.0 (2022-01-27)
 
 - Added banner image to a `README.md` file;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ----
 
-## v3.0.1 (2022-01-27)
+## v3.0.1 (2022-01-28)
 
 - Removed budge from `README.md` file that shows stable release;
 

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ All options are available in `Serhii\Ago\Option::class` as constants.
 
 | Option | Description |
 | --- | --- |
-| Option::ONLINE | Display "Online" if date interval within 60 seconds. After 60 seconds output will be the same as usually "x time ago" format. |
-| Option::NO_SUFFIX | Remove suffix from date and have "5 minutes" instead of "5 minutes ago". |
-| Option::JUST_NOW | Prints `Just now` when time is within 1 minutes. For example instead of `34 seconds ago` it will print `Just know` |
+| ONLINE | Display "Online" if date interval within 60 seconds. After 60 seconds output will be the same as usually "x time ago" format. Incompatible with option `JUST_NOW` |
+| NO_SUFFIX | Remove suffix from date and have "5 minutes" instead of "5 minutes ago". |
+| JUST_NOW | Prints `Just now` when time is within 1 minutes. For example instead of `34 seconds ago` it will print `Just know`. Incompatible with option `ONLINE`. |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![Ago package](https://serhii.io/storage/other/ago.png)
 
 [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2FSerhiiCho%2Fago%2Fbadge&style=flat)](https://actions-badge.atrox.dev/SerhiiCho/ago/goto)
-[![Latest Stable Version](https://poser.pugx.org/serhii/ago/v/stable)](https://packagist.org/packages/serhii/ago)
 [![Total Downloads](https://poser.pugx.org/serhii/ago/downloads)](https://packagist.org/packages/serhii/ago)
 [![License](https://poser.pugx.org/serhii/ago/license)](https://packagist.org/packages/serhii/ago)
 <a href="https://php.net/" rel="nofollow"><img src="https://camo.githubusercontent.com/2b1ed18c21257b0a1e6b8568010e6e8f3636e6d5/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f7068702d253345253344253230372e312d3838393242462e7376673f7374796c653d666c61742d737175617265" alt="Minimum PHP Version" data-canonical-src="https://img.shields.io/badge/php-%3E%3D%207.1-8892BF.svg" style="max-width:100%;"></a>

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ All options are available in `Serhii\Ago\Option::class` as constants.
 | --- | --- |
 | Option::ONLINE | Display "Online" if date interval within 60 seconds. After 60 seconds output will be the same as usually "x time ago" format. |
 | Option::NO_SUFFIX | Remove suffix from date and have "5 minutes" instead of "5 minutes ago". |
+| Option::JUST_NOW | Prints `Just now` when time is within 1 minutes. For example instead of `34 seconds ago` it will print `Just know` |
 
 ## Quick Start
 

--- a/resources/lang/en.php
+++ b/resources/lang/en.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 return [
 
     'ago' => 'ago',
-    'online' => 'Online', // Uppercase first letter
+    'just_now' => 'Just now',
+    'online' => 'Online',
     'second' => 'second',
     'seconds' => 'seconds',
     'minute' => 'minute',

--- a/resources/lang/nl.php
+++ b/resources/lang/nl.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 return [
 
     'ago' => 'geleden',
-    'online' => 'Online', // Uppercase first letter
+    'just_now' => 'Net nu',
+    'online' => 'Online',
     'second' => 'seconde',
     'seconds' => 'seconden',
     'minute' => 'minuut',

--- a/resources/lang/ru.php
+++ b/resources/lang/ru.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 return [
 
     'ago' => 'назад',
-    'online' => 'В сети', // Uppercase first letter
+    'just_now' => 'Только что',
+    'online' => 'В сети',
     'second' => 'секунда',
     'seconds' => 'секунды',
     'seconds-special' => 'секунд',

--- a/resources/lang/uk.php
+++ b/resources/lang/uk.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 return [
 
     'ago' => 'назад',
-    'online' => 'В мережі', // Uppercase first letter
+    'just_now' => 'Щойно',
+    'online' => 'В мережі',
     'second' => 'секунда',
     'seconds' => 'секунди',
     'seconds-special' => 'секунд',

--- a/src/Exceptions/InvalidOptionsException.php
+++ b/src/Exceptions/InvalidOptionsException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Serhii\Ago\Exceptions;
+
+use Exception;
+
+class InvalidOptionsException extends Exception
+{
+    //
+}

--- a/src/Option.php
+++ b/src/Option.php
@@ -9,4 +9,5 @@ class Option
     public const ONLINE = 1;
     public const UPCOMING = 2;
     public const NO_SUFFIX = 3;
+    public const JUST_NOW = 4;
 }

--- a/src/TimeAgo.php
+++ b/src/TimeAgo.php
@@ -97,6 +97,8 @@ final class TimeAgo
         switch (true) {
             case $this->optionIsSet(Option::ONLINE) && $seconds < 60:
                 return Lang::trans('online');
+            case $this->optionIsSet(Option::JUST_NOW) && $seconds < 60:
+                return Lang::trans('just_now');
             case $seconds < 60:
                 return $this->getWords('seconds', $seconds);
             case $minutes < 60:

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -6,6 +6,7 @@ namespace Serhii\Tests;
 
 use Carbon\CarbonImmutable;
 use PHPUnit\Framework\TestCase;
+use Serhii\Ago\Exceptions\InvalidOptionsException;
 use Serhii\Ago\Lang;
 use Serhii\Ago\Option;
 use Serhii\Ago\TimeAgo;
@@ -158,5 +159,14 @@ class OptionsTest extends TestCase
 
             $this->assertSame('Just now', $res, $msg);
         }
+    }
+
+    /** @test */
+    public function exception_is_thrown_if_option_online_and_option_just_now_are_passed_at_the_same_time(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $date = strtotime('now - 10 minutes');
+        TimeAgo::trans($date, [Option::ONLINE, Option::JUST_NOW]);
     }
 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -21,7 +21,11 @@ class OptionsTest extends TestCase
 
         for ($i = 0; $i < 60; $i++) {
             $date = CarbonImmutable::now()->subSeconds($i)->toDateTimeString();
-            $this->assertSame('В сети', TimeAgo::trans($date, Option::ONLINE));
+
+            $res = TimeAgo::trans($date, Option::ONLINE);
+            $msg = "Expected 'В сети' but result is '$res' with input $date";
+
+            $this->assertSame('В сети', $res, $msg);
         }
     }
 
@@ -139,5 +143,20 @@ class OptionsTest extends TestCase
             ['ru', CarbonImmutable::now()->subMonth()->toDateTimeString(), '1 месяц'],
             ['ru', CarbonImmutable::now()->subYear()->toDateTimeString(), '1 год'],
         ];
+    }
+
+    /** @test */
+    public function returns_just_now_within_60_seconds_if_JUST_NOW_options_is_set(): void
+    {
+        Lang::set('en');
+
+        for ($i = 0; $i < 60; $i++) {
+            $date = CarbonImmutable::now()->subSeconds($i)->toDateTimeString();
+
+            $res = TimeAgo::trans($date, Option::JUST_NOW);
+            $msg = "Expected 'Just now' but result is '$res' with input $date";
+
+            $this->assertSame('Just now', $res, $msg);
+        }
     }
 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -14,39 +14,15 @@ use function SandFox\Debug\call_private_method;
 
 class OptionsTest extends TestCase
 {
-    /**
-     * @dataProvider provider_returns_online_within_60_seconds_and_if_second_arg_is_passes
-     * @test
-     *
-     * @param int $seconds
-     * @param string $lang
-     *
-     * @throws \Exception
-     */
-    public function returns_online_within_60_seconds_if_ONLINE_options_is_set(int $seconds, string $lang): void
+    /** @test */
+    public function returns_online_within_60_seconds_if_ONLINE_options_is_set(): void
     {
-        Lang::set($lang);
+        Lang::set('ru');
 
-        $date = CarbonImmutable::now()->subSeconds($seconds)->toDateTimeString();
-        $time = TimeAgo::trans($date, Option::ONLINE);
-
-        $this->assertSame($lang === 'ru' ? 'В сети' : 'Online', $time);
-    }
-
-    public function provider_returns_online_within_60_seconds_and_if_second_arg_is_passes(): array
-    {
-        return [
-            [1, 'en'],
-            [2, 'en'],
-            [30, 'en'],
-            [20, 'en'],
-            [58, 'en'],
-            [1, 'ru'],
-            [2, 'ru'],
-            [20, 'ru'],
-            [30, 'ru'],
-            [58, 'ru'],
-        ];
+        for ($i = 0; $i < 60; $i++) {
+            $date = CarbonImmutable::now()->subSeconds($i)->toDateTimeString();
+            $this->assertSame('В сети', TimeAgo::trans($date, Option::ONLINE));
+        }
     }
 
     /** @test */


### PR DESCRIPTION
- Removed budge from `README.md` file that shows stable release;
- Added `Option::JUST_NOW` option that print `Just now` if time is within 1 minute;
- Added throwing `InvalidOptionsException` when you pass `JUST_NOW` and `ONLINE` options at the same time;